### PR TITLE
Fix for 0.6

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,5 +1,6 @@
 using Base.Test
 using Cubature
+using Compat
 
 # The downside of having multiple interfaces to simplify 1d, scalar
 # integrands, etcetera, is that we have lot of interfaces to test:
@@ -7,23 +8,23 @@ using Cubature
 @test_approx_eq_eps hquadrature(cos, 0,1, abstol=1e-8)[1] sin(1) 1e-8
 @test_approx_eq_eps pquadrature(cos, 0,1, abstol=1e-8)[1] sin(1) 1e-8
 
-quad_tst1(x) = prod(cos(x))    
+quad_tst1(x) = @compat prod(cos.(x))
 for dim = 0:3
     xmin = zeros(dim)
     xmax = 1:dim
-    ans = prod(sin(xmax))
+    ans = @compat prod(sin.(xmax))
     @test_approx_eq_eps hcubature(quad_tst1, xmin,xmax, abstol=1e-8)[1] ans 1e-8
     @test_approx_eq_eps pcubature(quad_tst1, xmin,xmax, abstol=1e-8)[1] ans 1e-8
 end
 
 quad_tst2(x, v) = for j = 1:length(v)
-    v[j] = prod(cos(x)) * j
+    v[j] = @compat prod(cos.(x)) * j
 end
 for fdim = 1:3
 for dim = 0:3
     xmin = zeros(dim)
     xmax = 1:dim
-    ans = prod(sin(xmax)) * (1:fdim)
+    ans = @compat prod(sin.(xmax)) * (1:fdim)
     if dim == 1
         @test_approx_eq_eps hquadrature(fdim, quad_tst2, xmin,xmax, abstol=1e-8)[1] ans 1e-8
         @test_approx_eq_eps pquadrature(fdim, quad_tst2, xmin,xmax, abstol=1e-8)[1] ans 1e-8
@@ -40,19 +41,19 @@ end
 @test_approx_eq_eps pquadrature_v(quad_tst0v, 0,1, abstol=1e-8)[1] sin(1) 1e-8
 
 quad_tst1v(x,v) = for i = 1:length(v)
-    v[i] = prod(cos(x[:,i]))
+    v[i] = @compat prod(cos.(x[:,i]))
 end
 for dim = 0:3
     xmin = zeros(dim)
     xmax = 1:dim
-    ans = prod(sin(xmax))
+    ans = @compat prod(sin.(xmax))
     @test_approx_eq_eps hcubature_v(quad_tst1v, xmin,xmax, abstol=1e-8)[1] ans 1e-8
     @test_approx_eq_eps pcubature_v(quad_tst1v, xmin,xmax, abstol=1e-8)[1] ans 1e-8
 end
 
 quad_tst2v(x::Array{Float64,2}, v) = for i = 1:size(v,2)
     for j = 1:size(v,1)
-        v[j,i] = prod(cos(x[:,i])) * j
+        v[j,i] = @compat prod(cos.(x[:,i])) * j
     end
 end
 quad_tst2v(x::Array{Float64,1}, v) = for i = 1:size(v,2)
@@ -64,7 +65,7 @@ for fdim = 1:3
 for dim = 0:3
     xmin = zeros(dim)
     xmax = 1:dim
-    ans = prod(sin(xmax)) * (1:fdim)
+    ans = @compat prod(sin.(xmax)) * (1:fdim)
     if dim == 1
         @test_approx_eq_eps hquadrature_v(fdim, quad_tst2v, xmin,xmax, abstol=1e-8)[1] ans 1e-8
         @test_approx_eq_eps pquadrature_v(fdim, quad_tst2v, xmin,xmax, abstol=1e-8)[1] ans 1e-8


### PR DESCRIPTION
* Fix vectorized function depwarn
* Remove `cfunction` cache
* Avoid dynamic dispatch in callback

~~DO NOT MERGE NOW!~~

~~The broadcast fix is independent and is missing `@compat`. The `cfunction` fix requires https://github.com/JuliaLang/julia/pull/19801 and can also be further improved to eliminate dynamic dispatch in the callback. This is used mainly as a use/test case for https://github.com/JuliaLang/julia/pull/19801. ~~
