### PR TITLE
add Compat to REQURIE and ignore build.log

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 deps/installed_vers
 deps/libcubature.*
 deps/cubature-*
+deps/build.log

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,2 +1,3 @@
 BinDeps
 julia 0.7
+Compat


### PR DESCRIPTION
Compat is used but is not declared as a dependency.

This package needs updating to Project.toml but at least this will make the script pickup the Compat dependency.